### PR TITLE
New FEBRABAN base rule

### DIFF
--- a/lib/utils/calculate-expiration-factor.js
+++ b/lib/utils/calculate-expiration-factor.js
@@ -10,6 +10,20 @@ export default function (expirationDate: Date): string {
     return '0000'
   }
 
+  // After 2025-02-22 new base time FEBRABAN resolution
+  if (
+    expirationTime.year() > 2025 ||
+    (expirationTime.year() === 2025 && expirationTime.month() > 1) ||
+    (expirationTime.year() === 2025 &&
+      expirationTime.month() === 1 &&
+      expirationTime.date() > 21)
+  ) {
+    const newBaseTime = moment([2025, 1, 22])
+    const diff = expirationTime.diff(newBaseTime, 'days') + 1000
+
+    return addLeadingZeros(String(diff), 4)
+  }
+  
   const diff = expirationTime.diff(baseTime, 'days')
   return addLeadingZeros(String(diff), 4)
 }

--- a/test/utils/calculate-expiration-factor.test.js
+++ b/test/utils/calculate-expiration-factor.test.js
@@ -7,6 +7,13 @@ describe('calculateExpirationFactor main funcionality', () => {
     expect(calculateExpirationFactor(new Date(2017, 11, 4))).toBe('7363')
   })
 
+  it('calculateExpirationFactor after 2025-02-22', () => {
+    expect(calculateExpirationFactor(new Date(2026, 1, 21))).toBe('1364')
+    expect(calculateExpirationFactor(new Date(2025, 2, 21))).toBe('1027')
+    expect(calculateExpirationFactor(new Date(2025, 1, 22))).toBe('1000')
+    expect(calculateExpirationFactor(new Date(2049, 9, 13))).toBe('9999')
+  })
+
   it('should handle expiration dates prior to 1997', () => {
     expect(calculateExpirationFactor(new Date(0))).toBe('0000')
     expect(calculateExpirationFactor(new Date(1997, 6, 10))).toBe('0000')


### PR DESCRIPTION
21-feb-2025 rules to the limit of expiration factor (9999). FEBRABAN decided to restart the counting from 1000 beginning on 22-feb-2025. I tried just changing the necessary code.

https://assinaturas.superlogica.com/hc/pt-br/articles/29654851094807-Fator-de-Vencimento-dos-Boletos-Atualiza%C3%A7%C3%A3o-FEBRABAN-o-que-vai-mudar